### PR TITLE
Provide defaults via secrets for all but image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,70 @@
 # deploy-to-kubernetes
 Action for deploying a ghcr image to a kuberenetes cluster
 
+## Example
 To use this action:
 ```
    - name: Deploy to NAMESPACE
       uses: mlibrary/deploy-to-kubernetes@v1
       with:
-        github_username: ${{ github.actor }}
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        image: ORGANIZATION/IMAGE_NAME:TAG
-        cluster_ca: YOUR_BASE64_ENCODED_CLUSTER_CA
-        cluster_server: YOUR_KUBERNETES_SERVER
-        namespace_token: YOUR_BASE64_ENCODED_TOKEN_FOR_DEPLOYING_TO_YOUR_NAMESPACE
-        namespace: NAMESPACE_YOUR_ARE_DEPLOYING_TO
-        deployment: YOUR_DEPLOYMENT_NAME #default is 'web'
-        container: YOUR_CONTAINER_NAME #default is 'web'
+        image: myorganization/my_app:latest
 ```
+
+## Required Argument
+
+### `image`
+
+The image to deploy. `ghcr.io/` is prepended, so if you provide e.g.
+`myorganization/my_app:latest`, the actual image that will be used is
+`ghcr.io/myorganization/my_app:latest`.
+
+## Optional Arguments
+
+These inputs all have defaults.
+
+### `deployment`
+
+The deployment whose image to set. Defaults to `web`.
+
+### `container`
+
+The container in the deployment whose image to set. Defaults to `web`.
+
+### `github_username`
+
+The username to use to log in to GCHR. Defaults to `${{ github.actor }}`. In
+most cases you should not need to change this.
+
+### `github_token`
+
+The PAT to use to log in to GHCR. Defaults to `${{ secrets.GITHUB_TOKEN }}`. In
+most cases you should not need to change this.
+
+### `cluster_server`
+
+The Kubernetes server. Defaults to `${{ secrets.KUBERNETES_SERVER }}`.
+
+### `cluster_ca`
+
+The Kubernetes cluster CA certificate, base64-encoded, e.g. from:
+
+```bash
+cat ~/.kube/certs/my-cluster/k8s-ca.crt | base64
+```
+
+Defaults to `${{ secrets.KUBERNETES_CA }}`.
+
+### `namespace_token`
+
+A base64-encoded Kubernetes service account token that can be used to set the
+image for the given deployment in the given namespace, e.g. from:
+
+```bash
+kubectl -n my-namespace get -o json secret my-service-token | jq -r .data.token
+```
+
+Defaults to `${{ secrets.KUBERNETES_TOKEN }}`.
+
+### `namespace`
+
+The Kubernetes namespace to deploy to. Defaults to `${{ secrets.NAMESPACE }}`

--- a/action.yml
+++ b/action.yml
@@ -3,19 +3,25 @@ description: 'Deploys a ghcr image to a Kubernetes Cluster'
 inputs:
   github_username:
     required: true
+    default: ${{ github.actor }}
   github_token:
     required: true
+    default: ${{ secrets.GITHUB_TOKEN }}
   image:
     required: true
     description: organization/image_name
   cluster_ca:
     required: true
+    default: ${{ secrets.KUBERNETES_CA }}
   cluster_server:
     require: true
+    default: ${{ secrets.KUBERNETES_SERVER }}
   namespace_token:
     required: true
+    default: ${{ secrets.KUBERNETES_TOKEN }}
   namespace:
     required: true
+    default: ${{ secrets.NAMESPACE }}
   deployment:
     required: true
     default: 'web'


### PR DESCRIPTION
I think we can default `github_username` and `github_token` for sure. I'm less certain about the kubernetes env vars, but I think it makes more sense to reference/document them here than it does to repeat the same secrets across every workflow that references this.

It's perhaps a little bit confusing that `ghcr.io/` gets automatically prepended to the image here, given that in the build workflows (e.g. https://github.com/mlibrary/patron_account/blob/main/.github/workflows/build-main.yaml) it doesn't.