### PR TITLE
Prepends "ghcr.io" to the image name if needed

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,5 @@
-name: 'MLibrary Deploy to Kubernetes Cluster' 
+---
+name: 'MLibrary Deploy to Kubernetes Cluster'
 description: 'Deploys a ghcr image to a Kubernetes Cluster'
 inputs:
   github_username:
@@ -39,28 +40,65 @@ runs:
         registry: ghcr.io
         username: ${{ inputs.github_username }}
         password: ${{ inputs.github_token }}
-    - name: Check that the tag exists
-      run: docker manifest inspect ghcr.io/${{ inputs.image }} > /dev/null
+    - name: Prepend ghcr.io to image name if necessary
+      id: image_name
+      uses: actions/github-script@v6
+      env:
+        IMAGE: ${{ inputs.image }}
+      with:
+        script: |
+          image = process.env.IMAGE
+          if(!image.startsWith('ghcr.io/')) {
+            image = "ghcr.io/" + image
+          }
+          core.setOutput('image',image)
+    - name: Check that the image & tag exist
+      run: docker manifest inspect "$IMAGE" > /dev/null
       shell: bash
+      env:
+        IMAGE: ${{ steps.image_name.outputs.image }}
     - uses: azure/setup-kubectl@v1
     - name: Authenticate with kubernetes
       shell: bash
       run: |
         mkdir -p ${HOME}/.kube/certs/cluster
         echo ${{ inputs.cluster_ca }} | base64 -d > ${HOME}/.kube/certs/cluster/k8s-ca.crt
-        kubectl config set-cluster cluster --certificate-authority=${HOME}/.kube/certs/cluster/k8s-ca.crt --server=${{ inputs.cluster_server }}
-        kubectl config set-credentials default --token=`echo ${{ inputs.namespace_token }} | base64 -d`
-        kubectl config set-context default --cluster=cluster --user=default --namespace=${{ inputs.namespace }}
+        kubectl config set-cluster cluster --certificate-authority=${HOME}/.kube/certs/cluster/k8s-ca.crt --server="$CLUSTER_SERVER"
+        kubectl config set-credentials default --token=$(echo "$NAMESPACE_TOKEN" | base64 -d)
+        kubectl config set-context default --cluster=cluster --user=default --namespace="$NAMESPACE"
         kubectl config use-context default
+      env:
+        CLUSTER_CA: ${{ inputs.cluster_ca }}
+        CLUSTER_SERVER: ${{ inputs.cluster_server }}
+        NAMESPACE_TOKEN: ${{ inputs.namespace_token }}
+        NAMESPACE: ${{ inputs.namespace }}
     - name: Deploy
       shell: bash
       run: |
-        if echo ${{ inputs.type }} | grep -c "deployment"
-        then
-          kubectl set image deployment ${{ inputs.deployment }} ${{ inputs.container }}=ghcr.io/${{ inputs.image }}
-        elif echo ${{ inputs.type }} | grep -c "cronjob"
-        then
-          kubectl patch cronjob ${{ inputs.cronjob_name }} --type=json -p='[{"op":"replace", "path": "/spec/jobTemplate/spec/template/spec/containers/0/image", "value":"ghcr.io/${{ inputs.image }}"}]'
-        else
-          echo "type must be deployment or cronjob"
-        fi
+        case "$TYPE" in
+          deployment)
+            kubectl set image deployment "$DEPLOYMENT" "$CONTAINER"="$IMAGE"
+            ;;
+          cronjob)
+            json=$(cat <<EOT
+            [
+              {
+                "op": "replace",
+                "path": "/spec/jobTemplate/spec/template/spec/containers/0/image",
+                "value": "$IMAGE"
+              }
+            ]
+        EOT
+            )
+            kubectl patch cronjob "$CRONJOB_NAME" --type=json -p="$json"
+            ;;
+          *)
+            echo "type must be deployment or cronjob"
+            exit 1;
+        esac
+      env:
+        TYPE: ${{ inputs.type }}
+        DEPLOYMENT: ${{ inputs.deployment }}
+        CRONJOB_NAME: ${{ inputs.cronjob_name }}
+        CONTAINER: ${{ inputs.container }}
+        IMAGE: ${{ steps.image_name.outputs.image }}


### PR DESCRIPTION
- Adds a step to check the image name, ensure that it begins with
ghcr.io, and add it if it is missing. This maintains backwards
compatibility with the existing version of the action that always prepends `ghcr.io`, while allowing for the full image name (including `ghcr.io`) to be included.

- Clean up formatting and interpolation of input parameters; this makes
the bash scripts more readable while making it clearer what information
each step uses.