### PR TITLE
Require specifying registry in image name

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ To use this action to deploy a deployment image:
    - name: Deploy to NAMESPACE
       uses: mlibrary/deploy-to-kubernetes@v1
       with:
-        image: myorganization/my_app:latest
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        image: ghcr.io/myorganization/my_app:latest
+        registry_token: ${{ secrets.GITHUB_TOKEN }}
         cluster_server: my-kubernetes-server
         cluster_ca: ${{ secrets.KUBERNETES_CA }}
         namespace_token: ${{ secrets.NAMESPACE_CA }}
@@ -21,8 +21,8 @@ To use this action to deploy a cronjob image
    - name: Deploy to NAMESPACE
       uses: mlibrary/deploy-to-kubernetes@v1
       with:
-        image: myorganization/my_app:latest
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        image: ghcr.io/myorganization/my_app:latest
+        registry_token: ${{ secrets.GITHUB_TOKEN }}
         cluster_server: my-kubernetes-server
         cluster_ca: ${{ secrets.KUBERNETES_CA }}
         namespace_token: ${{ secrets.NAMESPACE_CA }}
@@ -36,13 +36,11 @@ To use this action to deploy a cronjob image
 
 ### `image`
 
-The image to deploy. `ghcr.io/` is prepended, so if you provide e.g.
-`myorganization/my_app:latest`, the actual image that will be used is
-`ghcr.io/myorganization/my_app:latest`.
+The image to deploy, e.g.  `ghcr.io/myorganization/my_app:v1.2.3`.
 
-### `github_token`
+### `registry_token`
 
-The PAT to use to log in to GHCR. This shold be `${{ secrets.GITHUB_TOKEN }}`. 
+The token to use to log in to the registry. For GHCR this shold be `${{ secrets.GITHUB_TOKEN }}`. 
 
 ### `cluster_server`
 
@@ -81,10 +79,14 @@ The deployment whose image to set. Defaults to `web`.
 
 The container in the deployment whose image to set. Defaults to `web`.
 
-### `github_username`
+### `registry_username`
 
-The username to use to log in to GCHR. Defaults to `${{ github.actor }}`. In
-most cases you should not need to change this.
+The username to use to log in to the registry. Defaults to `${{ github.actor
+}}`. For GHCR you should not need to change this.
+
+### `registry`
+
+The registry to log in to.
 
 ### `type`
 

--- a/action.yml
+++ b/action.yml
@@ -1,66 +1,105 @@
-name: 'MLibrary Deploy to Kubernetes Cluster' 
-description: 'Deploys a ghcr image to a Kubernetes Cluster'
+---
+name: 'MLibrary Deploy to Kubernetes Cluster'
+description: 'Deploys an image to a Kubernetes Cluster'
 inputs:
-  github_username:
-    required: true
+  registry:
+    description: Registry to log into
+    default: ghcr.io
+  registry_username:
+    description: Username to log into the registry with
     default: ${{ github.actor }}
-  github_token:
+  registry_token:
+    decription: Token to log into the registry with
     required: true
   image:
+    description: Image to deploy, e.g. registry/organization/image_name:tag
     required: true
-    description: organization/image_name
   cluster_ca:
+    description: The Kubernetes cluster CA certificate, base64-encoded
     required: true
   cluster_server:
-    require: true
+    description: The Kubernetes server API endpoint
+    required: true
   namespace_token:
+    description: A base64-encoded Kubernetes service account token
     required: true
   namespace:
+    description: The Kubernetes namespace to deploy to
     required: true
+  type:
+    description: "'deployment' or 'cronjob'"
+    default: 'deployment'
   deployment:
-    required: true
+    description: >-
+      Used when type=deployment. The deployment whose image to set.
     default: 'web'
   container:
-    required: true
+    description: >-
+      Used when type=deployment. The container in the deployment whose image to
+      set.
     default: 'web'
-  type:
-    required: true
-    default: 'deployment'
-    description: "'deployment' or 'cronjob'"
   cronjob_name:
+    description: >-
+      Used when type=cronjob. The cronjob whose image to set; only updates the
+      first container for the cronjob
     required: false
 
 runs:
   using: "composite"
   steps:
-    - name: Log into Github Container Registry
+    - name: Log into container registry
       uses: docker/login-action@v1
       with:
-        registry: ghcr.io
-        username: ${{ inputs.github_username }}
-        password: ${{ inputs.github_token }}
-    - name: Check that the tag exists
-      run: docker manifest inspect ghcr.io/${{ inputs.image }} > /dev/null
+        registry: ${{ inputs.registry }}
+        username: ${{ inputs.registry_username }}
+        password: ${{ inputs.registry_token }}
+    - name: Check that the image & tag exist
+      run: docker manifest inspect "$IMAGE" > /dev/null
       shell: bash
+      env:
+        IMAGE: ${{ inputs.image }}
     - uses: azure/setup-kubectl@v1
     - name: Authenticate with kubernetes
       shell: bash
       run: |
         mkdir -p ${HOME}/.kube/certs/cluster
         echo ${{ inputs.cluster_ca }} | base64 -d > ${HOME}/.kube/certs/cluster/k8s-ca.crt
-        kubectl config set-cluster cluster --certificate-authority=${HOME}/.kube/certs/cluster/k8s-ca.crt --server=${{ inputs.cluster_server }}
-        kubectl config set-credentials default --token=`echo ${{ inputs.namespace_token }} | base64 -d`
-        kubectl config set-context default --cluster=cluster --user=default --namespace=${{ inputs.namespace }}
+        kubectl config set-cluster cluster --certificate-authority=${HOME}/.kube/certs/cluster/k8s-ca.crt --server="$CLUSTER_SERVER"
+        kubectl config set-credentials default --token=$(echo "$NAMESPACE_TOKEN" | base64 -d)
+        kubectl config set-context default --cluster=cluster --user=default --namespace="$NAMESPACE"
         kubectl config use-context default
+      env:
+        CLUSTER_CA: ${{ inputs.cluster_ca }}
+        CLUSTER_SERVER: ${{ inputs.cluster_server }}
+        NAMESPACE_TOKEN: ${{ inputs.namespace_token }}
+        NAMESPACE: ${{ inputs.namespace }}
     - name: Deploy
       shell: bash
       run: |
-        if echo ${{ inputs.type }} | grep -c "deployment"
-        then
-          kubectl set image deployment ${{ inputs.deployment }} ${{ inputs.container }}=ghcr.io/${{ inputs.image }}
-        elif echo ${{ inputs.type }} | grep -c "cronjob"
-        then
-          kubectl patch cronjob ${{ inputs.cronjob_name }} --type=json -p='[{"op":"replace", "path": "/spec/jobTemplate/spec/template/spec/containers/0/image", "value":"ghcr.io/${{ inputs.image }}"}]'
-        else
-          echo "type must be deployment or cronjob"
-        fi
+        case "$TYPE" in
+          deployment)
+            kubectl set image deployment "$DEPLOYMENT" "$CONTAINER"="$IMAGE"
+            ;;
+          cronjob)
+            json=$(cat <<EOT
+            [
+              {
+                "op": "replace",
+                "path": "/spec/jobTemplate/spec/template/spec/containers/0/image",
+                "value": "$IMAGE"
+              }
+            ]
+        EOT
+            )
+            kubectl patch cronjob "$CRONJOB_NAME" --type=json -p="$json"
+            ;;
+          *)
+            echo "type must be deployment or cronjob"
+            exit 1;
+        esac
+      env:
+        TYPE: ${{ inputs.type }}
+        DEPLOYMENT: ${{ inputs.deployment }}
+        CRONJOB_NAME: ${{ inputs.cronjob_name }}
+        CONTAINER: ${{ inputs.container }}
+        IMAGE: ${{ inputs.image }}


### PR DESCRIPTION
- Makes more consistent with other actions

- Allows specifying other registry but defaults to ghcr.io

- Clean up formatting and interpolation of input parameters; this makes
the bash scripts more readable while making it clearer what information
each step uses.