### PR TITLE
Defer most argument processing to kubectl set image

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@ Action for deploying a ghcr image to a kuberenetes cluster
 To use this action to deploy a deployment image:
 ```
    - name: Deploy to NAMESPACE
-      uses: mlibrary/deploy-to-kubernetes@v2
+      uses: mlibrary/deploy-to-kubernetes@v3
       with:
-        image: ghcr.io/myorganization/my_app:latest
         registry_token: ${{ secrets.GITHUB_TOKEN }}
-        cluster_server: my-kubernetes-server
+        image: ghcr.io/myorganization/my_app:latest
         cluster_ca: ${{ secrets.KUBERNETES_CA }}
+        cluster_server: my-kubernetes-server
         namespace_token: ${{ secrets.NAMESPACE_CA }}
         namespace: my-app-namespace
        
@@ -21,77 +21,37 @@ To use this action to deploy a cronjob image
    - name: Deploy to NAMESPACE
       uses: mlibrary/deploy-to-kubernetes@v2
       with:
-        image: ghcr.io/myorganization/my_app:latest
         registry_token: ${{ secrets.GITHUB_TOKEN }}
-        cluster_server: my-kubernetes-server
+        image: ghcr.io/myorganization/my_app:latest
         cluster_ca: ${{ secrets.KUBERNETES_CA }}
+        cluster_server: my-kubernetes-server
         namespace_token: ${{ secrets.NAMESPACE_CA }}
         namespace: my-app-namespace
         type: cronjob
-        cronjob_name: my-cronjob-name
+        resource: my-cronjob-name
+        container: my-cronjob-name
        
 ```
 
-## Required Arguments
+## Inputs
 
-### `image`
+### Required
 
-The image to deploy, e.g.  `ghcr.io/myorganization/my_app:v1.2.3`.
+| Name | Description | 
+|----------|-------------|
+| `registry_token` | The token to use to log in to the registry. For GHCR this shold be `${{ secrets.GITHUB_TOKEN }}`.|
+| `image`          | Image to deploy, e.g. `registry/organization/image_name:tag` |
+|`cluster_server`  | The Kubernetes server |
+| `cluster_ca`     | The Kubernetes cluster CA certificate, base64-encoded, e.g. from: <br/> `cat ~/.kube/certs/my-cluster/k8s-ca.crt \| base64`  |
+| `namespace_token`| A base64-encoded Kubernetes service account token that can be used to set the image for the given deployment in the given namespace, e.g. from: <br> `kubectl -n my-namespace get -o json secret my-service-token \| jq -r .data.token` |
+|`namespace`       | The Kubernetes namespace to deploy to.  |
 
-### `registry_token`
+### Optional 
 
-The token to use to log in to the registry. For GHCR this shold be `${{ secrets.GITHUB_TOKEN }}`. 
-
-### `cluster_server`
-
-The Kubernetes server. 
-
-### `cluster_ca`
-
-The Kubernetes cluster CA certificate, base64-encoded, e.g. from:
-
-```bash
-cat ~/.kube/certs/my-cluster/k8s-ca.crt | base64
-```
-
-### `namespace_token`
-
-A base64-encoded Kubernetes service account token that can be used to set the
-image for the given deployment in the given namespace, e.g. from:
-
-```bash
-kubectl -n my-namespace get -o json secret my-service-token | jq -r .data.token
-```
-
-### `namespace`
-
-The Kubernetes namespace to deploy to. 
-
-## Optional Arguments
-
-These inputs all have defaults.
-
-### `deployment`
-
-The deployment whose image to set. Defaults to `web`.
-
-### `container`
-
-The container in the deployment whose image to set. Defaults to `web`.
-
-### `registry_username`
-
-The username to use to log in to the registry. Defaults to `${{ github.actor
-}}`. For GHCR you should not need to change this.
-
-### `registry`
-
-The registry to log in to.
-
-### `type`
-
-The options are here are 'deployment' or 'cronjob'. Specfy 'cronjob' if a cronjob's image should be updated. Defaults to 'deployment'
-
-### `cronjob_name`
-
-Only needed if `type` is 'cronjob'. This is the name of the cronjob to which the new image should be applied.
+| Name | Description | Value |
+|------|-------------|-------|
+|`registry`| Registry to log in to | `ghcr.io` |
+|`registry_username`|  Username to log into the registry with | `${{ github.actor }}` |
+|`type`| Any resource type, comma-separated set of resource types, or 'all'| `deployment` |
+|`resource`| Name of the resource whose image to set, a label selector like `--selector='app=someapp'`, or `--all` | `web` |
+|`container`| The container in the resource whose image to set, or "*" for all containers | `web` | 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To use this action to deploy a deployment image to the `web` deployment and `web
 To use this action to deploy a cronjob image
 ```
    - name: Deploy to NAMESPACE
-      uses: mlibrary/deploy-to-kubernetes@v2
+      uses: mlibrary/deploy-to-kubernetes@v3
       with:
         registry_token: ${{ secrets.GITHUB_TOKEN }}
         image: ghcr.io/myorganization/my_app:latest

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # deploy-to-kubernetes
 Action for deploying a ghcr image to a kuberenetes cluster
 
+Uses [kubectl set image](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#-em-image-em-) command.
+
 ## Example
-To use this action to deploy a deployment image:
+To use this action to deploy a deployment image to the `web` deployment and `web` container:
 ```
    - name: Deploy to NAMESPACE
       uses: mlibrary/deploy-to-kubernetes@v3
@@ -27,8 +29,8 @@ To use this action to deploy a cronjob image
         cluster_server: my-kubernetes-server
         namespace_token: ${{ secrets.NAMESPACE_CA }}
         namespace: my-app-namespace
-        type: cronjob
-        resource: my-cronjob-name
+        resource_type: cronjob
+        resource_name: my-cronjob-name
         container: my-cronjob-name
        
 ```
@@ -52,6 +54,6 @@ To use this action to deploy a cronjob image
 |------|-------------|-------|
 |`registry`| Registry to log in to | `ghcr.io` |
 |`registry_username`|  Username to log into the registry with | `${{ github.actor }}` |
-|`type`| Any resource type, comma-separated set of resource types, or 'all'| `deployment` |
-|`resource`| Name of the resource whose image to set, a label selector like `--selector='app=someapp'`, or `--all` | `web` |
+|`resource_type`| Any resource type, comma-separated set of resource types, or 'all'| `deployment` |
+|`resource_name`| Name of the resource whose image to set, a label selector like `--selector='app=someapp'`, or `--all` | `web` |
 |`container`| The container in the resource whose image to set, or "*" for all containers | `web` | 

--- a/action.yml
+++ b/action.yml
@@ -27,22 +27,16 @@ inputs:
     description: The Kubernetes namespace to deploy to
     required: true
   type:
-    description: "'deployment' or 'cronjob'"
+    description: Any resource type, comma-separated set of resource types, or 'all'
     default: 'deployment'
-  deployment:
+  resource:
     description: >-
-      Used when type=deployment. The deployment whose image to set.
+      Name of the resource whose image to set, a label selector like "--selector='app=someapp'", or "--all"
     default: 'web'
   container:
     description: >-
-      Used when type=deployment. The container in the deployment whose image to
-      set.
+      The container in the resource whose image to set, or "*" for all containers
     default: 'web'
-  cronjob_name:
-    description: >-
-      Used when type=cronjob. The cronjob whose image to set; only updates the
-      first container for the cronjob
-    required: false
 
 runs:
   using: "composite"
@@ -76,30 +70,9 @@ runs:
     - name: Deploy
       shell: bash
       run: |
-        case "$TYPE" in
-          deployment)
-            kubectl set image deployment "$DEPLOYMENT" "$CONTAINER"="$IMAGE"
-            ;;
-          cronjob)
-            json=$(cat <<EOT
-            [
-              {
-                "op": "replace",
-                "path": "/spec/jobTemplate/spec/template/spec/containers/0/image",
-                "value": "$IMAGE"
-              }
-            ]
-        EOT
-            )
-            kubectl patch cronjob "$CRONJOB_NAME" --type=json -p="$json"
-            ;;
-          *)
-            echo "type must be deployment or cronjob"
-            exit 1;
-        esac
+        kubectl set image "$TYPE" "$RESOURCE" "$CONTAINER=$IMAGE"
       env:
         TYPE: ${{ inputs.type }}
-        DEPLOYMENT: ${{ inputs.deployment }}
-        CRONJOB_NAME: ${{ inputs.cronjob_name }}
+        RESOURCE: ${{ inputs.resource }}
         CONTAINER: ${{ inputs.container }}
         IMAGE: ${{ inputs.image }}

--- a/action.yml
+++ b/action.yml
@@ -26,10 +26,10 @@ inputs:
   namespace:
     description: The Kubernetes namespace to deploy to
     required: true
-  type:
+  resource_type:
     description: Any resource type, comma-separated set of resource types, or 'all'
     default: 'deployment'
-  resource:
+  resource_name:
     description: >-
       Name of the resource whose image to set, a label selector like "--selector='app=someapp'", or "--all"
     default: 'web'
@@ -70,9 +70,9 @@ runs:
     - name: Deploy
       shell: bash
       run: |
-        kubectl set image "$TYPE" "$RESOURCE" "$CONTAINER=$IMAGE"
+        kubectl set image "$RESOURCE_TYPE" "$RESOURCE_NAME" "$CONTAINER=$IMAGE"
       env:
-        TYPE: ${{ inputs.type }}
-        RESOURCE: ${{ inputs.resource }}
+        RESOURCE_TYPE: ${{ inputs.resource_type }}
+        RESOURCE_NAME: ${{ inputs.resource_name }}
         CONTAINER: ${{ inputs.container }}
         IMAGE: ${{ inputs.image }}


### PR DESCRIPTION
- set image *does* support cronjobs

- it also supports updating multiple resources, types of resources, and
  multiple containers